### PR TITLE
template parameter is never taken into consideration

### DIFF
--- a/packages/cli/src/commands/migrations/new.ts
+++ b/packages/cli/src/commands/migrations/new.ts
@@ -133,9 +133,11 @@ export default class Command extends CmaClientCommand {
 
     const config = this.datoProfileConfig!;
 
-    const template = config.migrations?.template
-      ? resolve(dirname(this.datoConfigPath), config.migrations?.template)
-      : undefined;
+    const template = flags.template
+      ? resolve(dirname(this.datoConfigPath), flags.template)
+      : config.migrations?.template
+        ? resolve(dirname(this.datoConfigPath), config.migrations?.template)
+        : undefined;
 
     const migrationsDir = config.migrations?.directory
       ? resolve(dirname(this.datoConfigPath), config.migrations?.directory)


### PR DESCRIPTION
**Issue on --template option**

`npx datocms migrations:new new-migration --template=./my-own.ts`

**Actual:**
 The command creates a migration with default template.

**Expected:**
The command creates a new migration using the custom template passed as parameter

**Solution**
Consider the path passed as `--template` during `const template` assignment.
IMO the option passed in the command line should also have priority over the option in the `datocms.config.json`.